### PR TITLE
Remove unnecessary sass-export reference

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,6 @@ import fs from 'fs';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import less from 'less';
 import lessToJS from 'less-vars-to-js';
-import { exporter } from 'sass-export';
 
 import ExtractVariablesPlugin from './extractVariablesLessPlugin';
 


### PR DESCRIPTION
This reference breaks projects depending on consumer's dependencies, and is unnecessary as of the latest commit from previous maintainers. 